### PR TITLE
Fix fragments for polymer build

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -2,9 +2,6 @@
   "entrypoint": "index.html",
   "shell": "src/charts-demo-app.html",
   "fragments": [
-    "src/sales-dashboard/sales-dashboard.html",
-    "src/image-collage/image-collage.html",
-    "src/row-types/row-types.html",
     "src/404/404.html"
   ],
   "sources": [


### PR DESCRIPTION
Current demo has no fragments, this avoids error with `polymer build`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-demo/5)
<!-- Reviewable:end -->
